### PR TITLE
Добавил скрипт для установки husky (читайте комменты)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "lint": "eslint ./src",
     "lint:fix": "eslint --fix --ext .js,.jsx ./src",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages -d build",
+    "prepare-husky":"husky install"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
husky, который позволяет линтит на коммите, убрал функцию автоустановки. Что это значит для нас: если мы хотим линт на коммите и реджект по неподходящему коммиту/коммиту который не прошел линт - придеться выполнить скрипт npm run prepare-husky . Один раз для рабочей директории, в любой ветке, после этого начинает работатьдля других веток тоже. По крайней мере у меня оно так работает.

Вопрос: надо оно нам или ебись оно все конем с такими лишними педалями? 
Я пользуюсь, но пропогандировать не буду. 